### PR TITLE
Fix price string rendering

### DIFF
--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -96,7 +96,7 @@ function fetchShipmentData(origin, destination, company, maxPrice) {
                             <a href="${company.website_url}" target="_blank" class="more-info">More Info</a>
                         </div>
                         <div class="price-and-book">
-                            <p class="price">$${company.price.toFixed(2)}</p>
+                            <p class="price">${company.price.toFixed(2)}</p>
                             <button class="book-now">Book Now</button>
                         </div>
                     `;


### PR DESCRIPTION
## Summary
- show only one dollar sign for prices in shipment options

## Testing
- `python -m py_compile app.py view_db.py`


------
https://chatgpt.com/codex/tasks/task_e_684070d0de74832b9d459df87561abe1