### PR TITLE
Fix slot machine element lookup

### DIFF
--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -3,14 +3,17 @@ const urlParams = new URLSearchParams(window.location.search);
 const initialOrigin = urlParams.get('origin');
 const initialDestination = urlParams.get('destination');
 
-setInterval(() => {
-    slotMachineText.classList.add('fade');
-    setTimeout(() => {
-        currentIndex = (currentIndex + 1) % words.length;
-        slotMachineText.textContent = words[currentIndex];
-        slotMachineText.classList.remove('fade');
-    }, 500); // Match this duration to the CSS transition time
-}, 2000);
+const slotMachineText = document.getElementById('slot-machine-text');
+if (slotMachineText) {
+    setInterval(() => {
+        slotMachineText.classList.add('fade');
+        setTimeout(() => {
+            currentIndex = (currentIndex + 1) % words.length;
+            slotMachineText.textContent = words[currentIndex];
+            slotMachineText.classList.remove('fade');
+        }, 500); // Match this duration to the CSS transition time
+    }, 2000);
+}
 
 // Fetch distinct companies, origins, and destinations and populate the filters
 fetch('/api/countries')


### PR DESCRIPTION
## Summary
- safely grab `slot-machine-text` element in `scripts.js`
- only start the text rotation interval if the element exists

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684070e0040c832b840c53f9db02d5d8