### PR TITLE
Add API tests and run them in CI

### DIFF
--- a/.github/workflows/azure-webapps-node.yml
+++ b/.github/workflows/azure-webapps-node.yml
@@ -48,6 +48,19 @@ jobs:
         npm run build --if-present
         npm run test --if-present
 
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flask pytest
+
+    - name: Run pytest
+      run: pytest
+
     - name: Upload artifact for deployment job
       uses: actions/upload-artifact@v3
       with:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,28 @@
+import json
+import os
+import sys
+
+# Add venv site-packages to sys.path if pytest runs without installed packages
+venv_packages = os.path.join(os.path.dirname(__file__), '..', 'venv', 'lib', 'python3.12', 'site-packages')
+if os.path.isdir(venv_packages) and venv_packages not in sys.path:
+    sys.path.insert(0, os.path.abspath(venv_packages))
+
+from app import app
+
+
+def test_companies_endpoint():
+    with app.test_client() as client:
+        response = client.get('/api/companies')
+        assert response.status_code == 200
+        assert response.is_json
+        assert isinstance(response.get_json(), list)
+
+
+def test_countries_endpoint():
+    with app.test_client() as client:
+        response = client.get('/api/countries')
+        assert response.status_code == 200
+        assert response.is_json
+        data = response.get_json()
+        assert isinstance(data, dict)
+        assert 'origins' in data and 'destinations' in data


### PR DESCRIPTION
## Summary
- add regression tests for API endpoints using Flask's test client
- run pytest in GitHub Actions workflow

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684070fb80dc832b82e8853767f3b66c